### PR TITLE
Add variable interpolation support

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,4 +1,4 @@
-# withenv Specification v1.0.2
+# withenv Specification v1.1.0
 
 `withenv` is a command-line utility that executes a program with environment variables loaded from a file.
 
@@ -101,13 +101,54 @@ Lines not matching this grammar are **malformed**. Implementations MUST warn to 
 3. **Whitespace**: Leading/trailing whitespace around keys is trimmed; whitespace at the start of unquoted values is preserved
 4. **Keys**: Must start with a letter or underscore, followed by letters, digits, or underscores. Unicode letters are permitted but may not be portable to all shells.
 5. **Quoting**: Values may be quoted with single (`'`) or double (`"`) quotes
-6. **Escape sequences**: Within double quotes, `\n`, `\r`, `\t`, `\\`, `\"`, and `\'` are interpreted. Only these escapes are interpreted; all others remain literal.
+6. **Escape sequences**: Within double quotes, `\n`, `\r`, `\t`, `\\`, `\"`, `\'`, and `\$` are interpreted. Only these escapes are interpreted; all others remain literal.
 7. **Single quotes**: Literal strings, no escape interpretation
 8. **Unquoted values**: Trailing whitespace is preserved, inline `#` is part of the value
 9. **Export prefix**: `export KEY=value` is equivalent to `KEY=value`
 10. **Empty values**: `KEY=` sets an empty string
 11. **Multiline**: Double-quoted values may span lines with `\n` or literal newlines
 12. **Quote concatenation**: When a quoted value is followed by additional content, the quoted portion and trailing content are concatenated (e.g., `KEY="hello"world` produces `helloworld`). Mixed quote styles are supported.
+
+### Variable Interpolation
+
+Variable references using `${VAR}` syntax are expanded in unquoted and double-quoted values.
+
+#### Syntax
+
+Only the braced form `${VAR}` is supported. The variable name must be a valid key (letter or underscore, followed by letters, digits, or underscores).
+
+#### Resolution Order
+
+1. **File-first**: If `VAR` was defined earlier in the same file, use that value
+2. **Environment fallback**: Otherwise, use the value from the process environment
+3. **Undefined**: If not found in either, emit a warning to stderr and expand to empty string
+
+#### Quoting Behavior
+
+- **Double quotes**: Interpolation occurs (`"${VAR}"` expands)
+- **Single quotes**: No interpolation (`'${VAR}'` is literal)
+- **Unquoted**: Interpolation occurs (`${VAR}` expands)
+
+#### Escaping
+
+Within double quotes, `\$` produces a literal `$` character, preventing interpolation.
+
+#### Timing
+
+Interpolation occurs during value parsing, before quote concatenation. This means `"${FOO}"bar` first expands `${FOO}`, then concatenates with `bar`.
+
+#### Self-Reference
+
+A variable may reference itself: `FOO=${FOO}_suffix`. Since `FOO` has no prior definition in the file, the environment value is used.
+
+#### Malformed References
+
+The following are malformed and cause the entire line to be skipped with a warning:
+
+- Unclosed brace: `${FOO`
+- Empty braces: `${}`
+- Invalid variable name: `${123bad}`, `${foo-bar}`
+- Unsupported syntax: `${VAR:-default}`, `${VAR:+alt}`, etc.
 
 ### Examples
 
@@ -128,6 +169,24 @@ EMPTY_VAR=
 
 # Export syntax (equivalent to without export)
 export API_KEY=secret123
+
+# Variable interpolation
+BASE_URL=https://api.example.com
+USERS_ENDPOINT=${BASE_URL}/users
+POSTS_ENDPOINT="${BASE_URL}/posts"
+
+# Reuse tokens across variable names
+DO_PAT=dop_v1_abc123
+TF_VAR_do_token=${DO_PAT}
+
+# Reference environment variable (HOME from process environment)
+CONFIG_DIR=${HOME}/.myapp
+
+# Literal dollar sign (escaped)
+PRICE="\$100"
+
+# Literal interpolation syntax (single quotes)
+TEMPLATE='${NOT_EXPANDED}'
 ```
 
 ## Error Conditions
@@ -164,7 +223,7 @@ export API_KEY=secret123
 
 ## Non-Goals
 
-- Variable interpolation (`${VAR}` expansion)
 - Sourcing multiple files
 - Watching files for changes
 - Acting as a process supervisor
+- Advanced substitution syntax (`${VAR:-default}`, `${VAR:+alt}`, etc.)

--- a/tests.yaml
+++ b/tests.yaml
@@ -1,4 +1,4 @@
-# withenv Test Suite v0.2.0
+# withenv Test Suite v1.1.0
 #
 # Language-agnostic test cases defining expected behavior.
 # Each test specifies inputs and expected outputs/behaviors.

--- a/tests.yaml
+++ b/tests.yaml
@@ -1,4 +1,4 @@
-# withenv Test Suite v0.1.0
+# withenv Test Suite v0.2.0
 #
 # Language-agnostic test cases defining expected behavior.
 # Each test specifies inputs and expected outputs/behaviors.
@@ -145,6 +145,14 @@ env_file_parsing:
     expect:
       exit_code: 0
       stdout: "it's escaped\n"
+
+  - name: escape dollar sign in double quotes
+    env_file: |
+      MONEY="\$50"
+    command: ["printenv", "MONEY"]
+    expect:
+      exit_code: 0
+      stdout: "$50\n"
 
   - name: unknown escape sequence preserved literally
     env_file: |
@@ -559,6 +567,237 @@ malformed_lines:
   - name: line with only key no equals is malformed
     env_file: |
       JUST_A_KEY
+      VALID=works
+    command: ["printenv", "VALID"]
+    expect:
+      exit_code: 0
+      stdout: "works\n"
+      stderr_contains: "warning"
+
+# =============================================================================
+# Variable Interpolation
+# =============================================================================
+
+variable_interpolation:
+  # Basic interpolation
+  - name: basic interpolation from earlier variable
+    env_file: |
+      FOO=hello
+      BAR=${FOO}
+    command: ["printenv", "BAR"]
+    expect:
+      exit_code: 0
+      stdout: "hello\n"
+
+  - name: interpolation with suffix
+    env_file: |
+      BASE=/opt/app
+      CONFIG=${BASE}/config
+    command: ["printenv", "CONFIG"]
+    expect:
+      exit_code: 0
+      stdout: "/opt/app/config\n"
+
+  - name: interpolation in double quotes
+    env_file: |
+      FOO=hello
+      BAR="${FOO} world"
+    command: ["printenv", "BAR"]
+    expect:
+      exit_code: 0
+      stdout: "hello world\n"
+
+  - name: multiple interpolations in one value
+    env_file: |
+      FIRST=hello
+      SECOND=world
+      COMBINED=${FIRST} ${SECOND}
+    command: ["printenv", "COMBINED"]
+    expect:
+      exit_code: 0
+      stdout: "hello world\n"
+
+  - name: chained interpolation
+    env_file: |
+      A=one
+      B=${A}
+      C=${B}
+    command: ["printenv", "C"]
+    expect:
+      exit_code: 0
+      stdout: "one\n"
+
+  # Resolution order: file-first, then environment
+  - name: file variable shadows environment
+    initial_env:
+      FOO: "from_env"
+    env_file: |
+      FOO=from_file
+      BAR=${FOO}
+    command: ["printenv", "BAR"]
+    expect:
+      exit_code: 0
+      stdout: "from_file\n"
+
+  - name: environment fallback when not in file
+    initial_env:
+      FROM_ENV: "env_value"
+    env_file: |
+      RESULT=${FROM_ENV}
+    command: ["printenv", "RESULT"]
+    expect:
+      exit_code: 0
+      stdout: "env_value\n"
+
+  - name: self-reference uses environment value
+    initial_env:
+      FOO: "original"
+    env_file: |
+      FOO=${FOO}_suffix
+    command: ["printenv", "FOO"]
+    expect:
+      exit_code: 0
+      stdout: "original_suffix\n"
+
+  # Undefined variables
+  - name: undefined variable expands to empty with warning
+    env_file: |
+      RESULT=${UNDEFINED_VAR}
+    command: ["printenv", "RESULT"]
+    expect:
+      exit_code: 0
+      stdout: "\n"
+      stderr_contains: "warning"
+
+  - name: empty defined variable expands to empty without warning
+    env_file: |
+      EMPTY=
+      RESULT=${EMPTY}
+    command: ["sh", "-c", "printenv RESULT; echo status=$?"]
+    expect:
+      exit_code: 0
+      stdout: "\nstatus=0\n"
+    # Note: no stderr_contains check - should be silent
+
+  # Quoting behavior
+  - name: single quotes prevent interpolation
+    env_file: |
+      FOO=hello
+      LITERAL='${FOO}'
+    command: ["printenv", "LITERAL"]
+    expect:
+      exit_code: 0
+      stdout: "${FOO}\n"
+
+  - name: double quotes allow interpolation
+    env_file: |
+      FOO=hello
+      EXPANDED="${FOO}"
+    command: ["printenv", "EXPANDED"]
+    expect:
+      exit_code: 0
+      stdout: "hello\n"
+
+  - name: unquoted allows interpolation
+    env_file: |
+      FOO=hello
+      EXPANDED=${FOO}
+    command: ["printenv", "EXPANDED"]
+    expect:
+      exit_code: 0
+      stdout: "hello\n"
+
+  # Escaping
+  - name: escaped dollar in double quotes
+    env_file: |
+      PRICE="\$100"
+    command: ["printenv", "PRICE"]
+    expect:
+      exit_code: 0
+      stdout: "$100\n"
+
+  - name: escaped dollar prevents interpolation
+    env_file: |
+      FOO=hello
+      LITERAL="\${FOO}"
+    command: ["printenv", "LITERAL"]
+    expect:
+      exit_code: 0
+      stdout: "${FOO}\n"
+
+  # Concatenation with interpolation
+  - name: interpolation before concatenation
+    env_file: |
+      FOO=hello
+      RESULT="${FOO}"world
+    command: ["printenv", "RESULT"]
+    expect:
+      exit_code: 0
+      stdout: "helloworld\n"
+
+  - name: interpolation in mixed quote concatenation
+    env_file: |
+      FOO=hello
+      RESULT="${FOO}"' world'
+    command: ["printenv", "RESULT"]
+    expect:
+      exit_code: 0
+      stdout: "hello world\n"
+
+  # Malformed interpolation syntax
+  - name: unclosed brace is malformed
+    env_file: |
+      BAD=${FOO
+      VALID=works
+    command: ["printenv", "VALID"]
+    expect:
+      exit_code: 0
+      stdout: "works\n"
+      stderr_contains: "warning"
+
+  - name: empty braces is malformed
+    env_file: |
+      BAD=${}
+      VALID=works
+    command: ["printenv", "VALID"]
+    expect:
+      exit_code: 0
+      stdout: "works\n"
+      stderr_contains: "warning"
+
+  - name: invalid variable name in braces is malformed
+    env_file: |
+      BAD=${123invalid}
+      VALID=works
+    command: ["printenv", "VALID"]
+    expect:
+      exit_code: 0
+      stdout: "works\n"
+      stderr_contains: "warning"
+
+  - name: hyphen in variable name is malformed
+    env_file: |
+      BAD=${foo-bar}
+      VALID=works
+    command: ["printenv", "VALID"]
+    expect:
+      exit_code: 0
+      stdout: "works\n"
+      stderr_contains: "warning"
+
+  - name: default value syntax is malformed
+    env_file: |
+      BAD=${FOO:-default}
+      VALID=works
+    command: ["printenv", "VALID"]
+    expect:
+      exit_code: 0
+      stdout: "works\n"
+      stderr_contains: "warning"
+
+  - name: alternate value syntax is malformed
+    env_file: |
+      BAD=${FOO:+alternate}
       VALID=works
     command: ["printenv", "VALID"]
     expect:


### PR DESCRIPTION
## Summary

- Adds `${VAR}` syntax for variable interpolation in `.env` files
- Resolution order: file-first (earlier definitions), then environment fallback
- Undefined variables emit warning and expand to empty string
- Single quotes prevent interpolation (literal)
- Adds `\$` escape sequence for literal dollar signs in double quotes
- Malformed references (unclosed braces, empty braces, invalid names, unsupported syntax like `${VAR:-default}`) cause line to be skipped with warning

## Changes

- **SPEC.md**: v1.0.2 → v1.1.0
  - Added `\$` to escape sequences (Rule 6)
  - New "Variable Interpolation" section with full specification
  - Updated examples to show interpolation usage
  - Updated Non-Goals to clarify advanced syntax is not supported

- **tests.yaml**: v0.1.0 → v0.2.0
  - Added 24 new test cases covering interpolation behavior

## Closes

Closes #2

## Test plan

- [ ] Review spec language for clarity and completeness
- [ ] Verify test cases cover all specified behaviors
- [ ] Check for edge cases not covered

🤖 Generated with [Claude Code](https://claude.ai/code)